### PR TITLE
Remove Digix to fix tests once it does not exists anymore in the ShapeShift API

### DIFF
--- a/assets.json
+++ b/assets.json
@@ -63,18 +63,6 @@
     "color": "#3EB13E"
   },
   {
-    "name": "digix",
-    "properName": "DigixDAO",
-    "decimals": 9,
-    "displayUnit": "DGD",
-    "shapeShiftUnit": "dgd",
-    "blockExplorer": "DGD",
-    "addresses": {
-        "current": "0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A"
-    },
-    "color": "#EEAF4A"
-  },
-  {
     "name": "district0x",
     "properName": "District0x",
     "decimals": 18,


### PR DESCRIPTION
This PR is removing Digix to fix the tests once it does not exists anymore in the ShapeShift API. As you can see here [here](https://shapeshift.io/legacy), [here](https://shapeshift.io/#/coins) and [here](https://shapeshift.io/getcoins).